### PR TITLE
feat: add interop with the crate `bvh-arena`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ bevy-06 = ["bevy-transform-06", "bevy-ecs-06"]
 # Public
 bevy-transform-06 = { package = "bevy_transform", version = "0.6.0", default-features = false, optional = true }
 bevy-ecs-06 = { package = "bevy_ecs", version = "0.6.0", default-features = false, optional = true }
+bvh-arena = { version = "1.0", default-features = false, optional = true }
 
 # Private
 glam = { version = "0.20.2", default-features = false, features = ["libm"] }

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ impacted = { version = "1.0.0", features = ["bevy-06"] }
 * `bevy-06` All [bevy](https://bevyengine.org) 0.6 interop (alias for `["bevy-transform-06", "bevy-ecs-06"]`)
 * `bevy-transform-06` Interoperability with [bevy_transform](https://crates.io/crates/bevy_transform) 0.6
 * `bevy-ecs-06` Interoperability with [bevy_ecs](https://crates.io/crates/bevy_ecs) 0.6
+* `bvh-arena` Interoperability with [bvh-arena](https://crates.io/crates/bvh-arena) bounding volumes
 
 
 ## MSRV

--- a/src/broad_phase_interop/bvh_arena.rs
+++ b/src/broad_phase_interop/bvh_arena.rs
@@ -1,0 +1,38 @@
+use bvh_arena::volumes::Aabb;
+use glam::Vec2;
+
+use crate::{CollisionShape, Support};
+
+impl From<&CollisionShape> for Aabb<2> {
+    fn from(shape: &CollisionShape) -> Self {
+        let min = [
+            shape.support(Vec2::new(-1.0, 0.0)).x,
+            shape.support(Vec2::new(0.0, -1.0)).y,
+        ];
+        let max = [
+            shape.support(Vec2::new(1.0, 0.0)).x,
+            shape.support(Vec2::new(0.0, 1.0)).y,
+        ];
+        Self::from_min_max(min, max)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::Vec2;
+
+    #[test]
+    fn from_rectangle() {
+        let expected = Aabb::from_min_max(Vec2::new(-0.5, -1.0), Vec2::new(0.5, 1.0));
+        let actual = Aabb::from(&CollisionShape::new_rectangle(1.0, 2.0));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn from_circle() {
+        let expected = Aabb::from_min_max(Vec2::new(-1.0, -1.0), Vec2::new(1.0, 1.0));
+        let actual = Aabb::from(&CollisionShape::new_circle(1.0));
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/broad_phase_interop/mod.rs
+++ b/src/broad_phase_interop/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "bvh-arena")]
+mod bvh_arena;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub use crate::deprecated::Error;
 use crate::shapes::ShapeData;
 pub use crate::transform::Transform;
 
+mod broad_phase_interop;
 mod deprecated;
 mod epa;
 mod gjk;


### PR DESCRIPTION
Make it possible to create a `bvh_arena::volumes::Aabb<2>`  from a collision shape reference.